### PR TITLE
[WIP] Allow forcing host architeture

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -506,8 +506,9 @@ function _storeHeader(firstLine, headers) {
 
   // keep-alive logic
   if (this._removedConnection) {
-    this._last = true;
-    this.shouldKeepAlive = false;
+    // shouldKeepAlive is generally true for HTTP/1.1. In that common case,
+    // even if the connection header isn't sent, we still persist by default.
+    this._last = !this.shouldKeepAlive;
   } else if (!state.connection) {
     const shouldSendKeepAlive = this.shouldKeepAlive &&
         (state.contLen || this.useChunkedEncodingByDefault || this.agent);

--- a/test/parallel/test-http-remove-connection-header-persists-connection.js
+++ b/test/parallel/test-http-remove-connection-header-persists-connection.js
@@ -1,0 +1,72 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const net = require('net');
+const http = require('http');
+
+const server = http.createServer(function(request, response) {
+  // When the connection header is removed, for HTTP/1.1 the connection should still persist.
+  // For HTTP/1.0, the connection should be closed after the response automatically.
+  response.removeHeader('connection');
+
+  response.end('beep boop\n');
+});
+
+const agent = new http.Agent({ keepAlive: true });
+
+function makeHttp11Request(cb) {
+  http.get({
+    port: server.address().port,
+    agent
+  }, function(res) {
+    const socket = res.socket;
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers.connection, undefined);
+
+    res.setEncoding('ascii');
+    let response = '';
+    res.on('data', function(chunk) {
+      response += chunk;
+    });
+    res.on('end', function() {
+      assert.strictEqual(response, 'beep boop\n');
+
+      // Wait till next tick to ensure that the socket is returned to the agent before
+      // we continue to the next request
+      process.nextTick(function() {
+        cb(socket);
+      });
+    });
+  });
+}
+
+function makeHttp10Request(cb) {
+  // We have to manually make HTTP/1.0 requests since Node does not allow sending them:
+  const socket = net.connect({ port: server.address().port }, function() {
+    socket.write('GET / HTTP/1.0\r\n' +
+               'Host: localhost:' + server.address().port + '\r\n' +
+                '\r\n');
+    socket.resume(); // Ignore the response itself
+
+    setTimeout(function() {
+      cb(socket);
+    }, 10);
+  });
+}
+
+server.listen(0, function() {
+  makeHttp11Request(function(firstSocket) {
+    makeHttp11Request(function(secondSocket) {
+      // Both HTTP/1.1 requests should have used the same socket:
+      assert.strictEqual(firstSocket, secondSocket);
+
+      makeHttp10Request(function(socket) {
+        // The server should have immediately closed the HTTP/1.0 socket:
+        assert.strictEqual(socket.closed, true);
+        server.close();
+      });
+    });
+  });
+});

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -28,6 +28,10 @@ set "common_test_suites=%JS_SUITES% %NATIVE_SUITES%&set build_addons=1&set build
 set config=Release
 set target=Build
 set target_arch=x64
+set host_arch=%PROCESSOR_ARCHITECTURE%
+if _%PROCESSOR_ARCHITEW6432%_==_AMD64_ set host_arch=amd64
+if _%host_arch%_==_AMD64_ set host_arch=amd64
+if _%host_arch%_==__ set host_arch=x64
 set ltcg=
 set target_env=
 set noprojgen=
@@ -83,6 +87,11 @@ if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
 if /i "%1"=="arm64"         set target_arch=arm64&goto arg-ok
+if /i "%1"=="ia32-host"     set host_arch=x86&goto arg-ok
+if /i "%1"=="x86-host"      set host_arch=x86&goto arg-ok
+if /i "%1"=="x64-host"      set host_arch=x64&goto arg-ok
+if /i "%1"=="amd64-host"    set host_arch=amd64&goto arg-ok
+if /i "%1"=="arm64-host"    set host_arch=arm64&goto arg-ok
 if /i "%1"=="vs2019"        set target_env=vs2019&goto arg-ok
 if /i "%1"=="vs2022"        set target_env=vs2022&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
@@ -206,7 +215,7 @@ if defined debug_nghttp2    set configure_flags=%configure_flags% --debug-nghttp
 if defined openssl_no_asm   set configure_flags=%configure_flags% --openssl-no-asm
 if defined no_shared_roheap set configure_flags=%configure_flags% --disable-shared-readonly-heap
 if defined DEBUG_HELPER     set configure_flags=%configure_flags% --verbose
-if "%target_arch%"=="x86" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set configure_flags=%configure_flags% --no-cross-compiling
+if "%target_arch%"=="x86" if "%host_arch%"=="amd64" set configure_flags=%configure_flags% --no-cross-compiling
 
 if not exist "%~dp0deps\icu" goto no-depsicu
 if "%target%"=="Clean" echo deleting %~dp0deps\icu
@@ -239,15 +248,12 @@ if defined noprojgen if defined nobuild goto :after-build
 
 @rem Set environment for msbuild
 
-set msvs_host_arch=x86
-if _%PROCESSOR_ARCHITECTURE%_==_AMD64_ set msvs_host_arch=amd64
-if _%PROCESSOR_ARCHITEW6432%_==_AMD64_ set msvs_host_arch=amd64
-@rem usually vcvarsall takes an argument: host + '_' + target
-set vcvarsall_arg=%msvs_host_arch%_%target_arch%
-@rem unless both host and target are x64
-if %target_arch%==x64 if %msvs_host_arch%==amd64 set vcvarsall_arg=amd64
-@rem also if both are x86
-if %target_arch%==x86 if %msvs_host_arch%==x86 set vcvarsall_arg=x86
+@rem usually vcvarsall takes an argument: host + '_' + target unless both host and target are the same
+if %target_arch%==%host_arch% (
+  set vcvarsall_arg=%target_arch% 
+) else (
+  set vcvarsall_arg=%host_arch%_%target_arch%
+)
 
 @rem Look for Visual Studio 2022
 :vs-set-2022
@@ -415,7 +421,7 @@ if errorlevel 1 echo Failed to sign exe, got error code %errorlevel%&goto exit
 if not defined licensertf goto stage_package
 
 set "use_x64_node_exe=false"
-if "%target_arch%"=="arm64" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "use_x64_node_exe=true"
+if "%target_arch%"=="arm64" if "%host_arch%"=="amd64" set "use_x64_node_exe=true"
 set "x64_node_exe=temp-vcbuild\node-x64-cross-compiling.exe"
 if "%use_x64_node_exe%"=="true" (
   echo Cross-compilation to ARM64 detected. We'll use the x64 Node executable for license2rtf.


### PR DESCRIPTION
This change allows forcing host architecture for the compilation. When running `vcbuild.bat` inside x64 Python shell on Arm64 marchine, Python always overwrites `PROCESSOR_ARCHITECTURE` environment variable with `AMD64`.

Contributes to https://github.com/dotnet-microsoft/ARM-on-Windows-Ecosystem/issues/202